### PR TITLE
Switch the image if there is a change in the DOM.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,14 +1,29 @@
 (function () {
-    document.querySelectorAll('img').forEach(function (img) {
-        chrome.storage.sync.get(null, function (items) {
-            if (items.data) {
-                items.data.forEach(function (switcher) {
-                    if (img.src.startsWith(switcher.from)) {
-                        img.src = switcher.to;
-                    }
-                });
-            }
+    function switchImages() {
+        document.querySelectorAll('img').forEach(function (img) {
+            chrome.storage.sync.get(null, function (items) {
+                if (items.data) {
+                    items.data.forEach(function (switcher) {
+                        if (img.src.startsWith(switcher.from)) {
+                            img.src = switcher.to;
+                        }
+                    });
+                }
+            });
         });
-    });
-}());
+    }
 
+    var lastTime = new Date().getTime();
+    var lastTimeDiff = 2000;
+    var mutationObserver = new MutationObserver(function () {
+        var date = new Date().getTime();
+        if ((date - lastTime) > lastTimeDiff) {
+            lastTime = date;
+            switchImages();
+        }
+    });
+
+    switchImages();
+    var body = document.querySelector('body');
+    mutationObserver.observe(body, {childList: true, subtree: true});
+}());


### PR DESCRIPTION
DOM の body を監視し、 DOM に変更があった時に画像の置換を実施する。  
しかし画像の置換は重い処理のため、2秒以上の間隔を持って `switchImages()` メソッドを実行する。

# なぜ2秒

ログを見てると body を監視するとかなりの頻度で `MutationObserver` が呼ばれるので、`MutationObserver` が呼ばれるたびに `switchImages()` が実行されるのでは重すぎる。
2秒くらいの差をつけて `switchImages()` すれば要件も満たせてパフォーマンスも良さそう。
1秒では短いし3秒では長いので2秒。