### PR TITLE
Switch the image partially.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,29 +1,55 @@
 (function () {
-    function switchImages() {
-        document.querySelectorAll('img').forEach(function (img) {
-            chrome.storage.sync.get(null, function (items) {
-                if (items.data) {
-                    items.data.forEach(function (switcher) {
-                        if (img.src.startsWith(switcher.from)) {
-                            img.src = switcher.to;
-                        }
-                    });
-                }
-            });
+    function switchImage(img) {
+        chrome.storage.sync.get(null, function (items) {
+            if (items.data) {
+                items.data.forEach(function (switcher) {
+                    if (img.src.startsWith(switcher.from)) {
+                        img.src = switcher.to;
+                    }
+                });
+            }
         });
     }
-
-    var lastTime = new Date().getTime();
-    var lastTimeDiff = 2000;
-    var mutationObserver = new MutationObserver(function () {
-        var date = new Date().getTime();
-        if ((date - lastTime) > lastTimeDiff) {
-            lastTime = date;
-            switchImages();
-        }
+    function switchAllImages() {
+        document.querySelectorAll('img').forEach(function (img) {
+            switchImage(img);
+        });
+    }
+    switchAllImages();
+    var mutationObserver = new MutationObserver(function (mutationRecordsList) {
+        mutationRecordsList.forEach(function (mutationRecord) {
+            switch(mutationRecord.type){
+                case "childList":
+                mutationRecord.addedNodes.forEach(function (addedNode) {
+                    if(addedNode instanceof HTMLElement) {
+                        addedNode.querySelectorAll('img').forEach(function (img) {
+                            switchImage(img);
+                        });
+                    }
+                });
+                break;
+                case "attributes":
+                if(mutationRecord.target instanceof HTMLElement) {
+                    if(mutationRecord.target.tagName.toLowerCase()==="img") {
+                      switchImage(mutationRecord.target);
+                    }
+                }
+                break;
+                default:
+                //DO NOTHING
+                break;
+            }
+        });
     });
 
-    switchImages();
     var body = document.querySelector('body');
-    mutationObserver.observe(body, {childList: true, subtree: true});
+    var config={
+        childList: true,
+        subtree: true,
+        attributes:true,
+        attributeFilter:["src"],
+    };
+    mutationObserver.observe(body, config);
+
+
 }());

--- a/main.js
+++ b/main.js
@@ -30,8 +30,8 @@
                 break;
                 case "attributes":
                 if(mutationRecord.target instanceof HTMLElement) {
-                    if(mutationRecord.target.tagName.toLowerCase()==="img") {
-                      switchImage(mutationRecord.target);
+                    if(mutationRecord.target.tagName.toLowerCase() === "img") {
+                        switchImage(mutationRecord.target);
                     }
                 }
                 break;
@@ -46,8 +46,8 @@
     var config={
         childList: true,
         subtree: true,
-        attributes:true,
-        attributeFilter:["src"],
+        attributes: true,
+        attributeFilter: ["src"],
     };
     mutationObserver.observe(body, config);
 


### PR DESCRIPTION
`MutationObserver`のcallbackに渡される`MutationRecord`を活用して、変更部分にのみ適用するように変更してみました。

あわせて`attributes`の監視も追加しました。
ImageSwitcherによる書き換えも検出しますので、toがfromに含まれている場合は連鎖的に書き換えが発生します。
使用用途を考えるとtoがfromに含まれることはありえないと考えていますが、厳密に運用するのであれば、`chrome.storage`への格納前にチェックする仕組みが必要かもしれません。